### PR TITLE
Getting rid of low volume output on headphones

### DIFF
--- a/audio/mixer_paths.xml
+++ b/audio/mixer_paths.xml
@@ -1074,14 +1074,16 @@
         <ctl name="RX2 MIX1 INP1" value="RX2" />
         <ctl name="CLASS_H_DSM MUX" value="DSM_HPHL_RX1" />
         <ctl name="HPHL DAC Switch" value="1" />
+        <!-- Disable compramators to improve audio quality -->
+        <ctl name="COMP1 Switch" value="0" />
         <!--80 % of 20 register: 0x1AE-->
-        <ctl name="HPHL Volume" value="16" />
+        <ctl name="HPHL Volume" value="17" />
         <!--80 % of 20 register: 0x1B4-->
-        <ctl name="HPHR Volume" value="16" />
+        <ctl name="HPHR Volume" value="17" />
         <!--66 % of 124 (rounded) register: 0x2B7-->
-        <ctl name="RX1 Digital Volume" value="82" />
+        <ctl name="RX1 Digital Volume" value="87" />
         <!--66 % of 124 (rounded) register: 0x2BF-->
-        <ctl name="RX2 Digital Volume" value="82" />
+        <ctl name="RX2 Digital Volume" value="87" />
     </path>
 
     <path name="headset-mic">


### PR DESCRIPTION
Improved volume output of headphones, to fix low volume on togari
Increased Analog gain (HPHL and HPHR)
Increased Digital Gain (RX1 and RX2)

And disabled compramator 1 to improve audio quality on low and high volume
